### PR TITLE
Allows for the sorting of columns

### DIFF
--- a/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
+++ b/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
@@ -1,23 +1,89 @@
+# frozen_string_literal: true
+
 module ActiveRecordMySqlStructure
+  # This module is used by the enhanced rake task to sanitize the structure.sql
   class StructureSqlSanitizer
+    COLUMN_REGEX = /^\s*`\w+`.*,+$/
+
+    # When set to true, the sanitizer will sort the columns of each table. This
+    # will help keep a consistent column order in the outputted structure file.
+    # The columns will be sorted alphabetically.
+    def self.sorted_columns=(val)
+      @sorted_columns = val
+    end
+
+    # Returns whether the structure should have alphabetically sorted columns.
+    def self.sorted_columns?
+      @sorted_columns
+    end
+
     def self.sanitize(filename)
-      structure_lines = ''
+      new(filename).sanitize!
+    end
+
+    attr_reader :filename
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    def sanitize!
+      lines = load_file
+      lines = sort_columns(lines) if self.class.sorted_columns?
+      lines = lines.join
+
+      # remove empty lines from the top using lstrip.
+      lines.lstrip!
+
+      # remove trailing lines from the bottom.
+      lines.chomp!
+
+      lines
+    end
+
+    private
+
+    def load_file
+      lines = []
       File.readlines(filename).each do |line|
         # get rid of SQL comments and MySQL SET directives.
         next if line.start_with?('--')
         next if line.start_with?('/*!')
 
         # get rid of AUTO_INCREMENT assignment in CREATE table statements.
-        line.gsub!(/\s+AUTO_INCREMENT=\d+\s+/, ' ') if line.include?('AUTO_INCREMENT=')
+        if line.include?('AUTO_INCREMENT=')
+          line.gsub!(/\s+AUTO_INCREMENT=\d+\s+/, ' ')
+        end
 
-        structure_lines << line
+        lines << line
+      end
+      lines
+    end
+
+    def sort_columns(lines)
+      cols = []
+      on_table = false
+      sorted_lines = []
+
+      lines.each do |line|
+        if on_table
+          if COLUMN_REGEX.match?(line)
+            cols << line
+          else
+            sorted_lines += cols.sort
+            sorted_lines << line
+            on_table = false
+            cols.clear
+          end
+        else
+          sorted_lines << line
+        end
+
+        # We know we are parsing a table.
+        on_table = true if line.include?('CREATE TABLE')
       end
 
-      # remove empty lines from the top using lstrip.
-      structure_lines.lstrip!
-
-      # remove trailing lines from the bottom.
-      structure_lines.chomp!
+      sorted_lines
     end
   end
 end

--- a/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
+++ b/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
@@ -18,18 +18,19 @@ module ActiveRecordMySqlStructure
     end
 
     def self.sanitize(filename)
-      new(filename).sanitize!
+      new(filename, sorted_columns: sorted_columns?).sanitize!
     end
 
-    attr_reader :filename
+    attr_reader :filename, :sorted_columns
 
-    def initialize(filename)
+    def initialize(filename, sorted_columns:)
       @filename = filename
+      @sorted_columns = sorted_columns
     end
 
     def sanitize!
       lines = load_file
-      lines = sort_columns(lines) if self.class.sorted_columns?
+      lines = sort_columns(lines) if sorted_columns
       lines = lines.join
 
       # remove empty lines from the top using lstrip.

--- a/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
+++ b/lib/activerecord-mysql-structure/active_record/structure_sql_sanitizer.rb
@@ -3,7 +3,7 @@
 module ActiveRecordMySqlStructure
   # This module is used by the enhanced rake task to sanitize the structure.sql
   class StructureSqlSanitizer
-    COLUMN_REGEX = /^\s*`\w+`.*,+$/
+    COLUMN_REGEX = /\A\s*`\w+`/
 
     # When set to true, the sanitizer will sort the columns of each table. This
     # will help keep a consistent column order in the outputted structure file.

--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'active_record'
 require 'activerecord-mysql-structure'
@@ -8,34 +10,25 @@ describe ActiveRecord::Mysql::Structure do
   end
 
   context 'StructureSqlSanitizer' do
-    describe '.sanitize' do
-      it 'should remove unwanted lines and substrings from structure.sql' do
-        filename = File.join(RSpec::root, 'data', 'structure.example.sql')
-        expected_filename = File.join(RSpec::root, 'data', 'structure.expected.sql')
+    let(:filename) { File.join(RSpec::root, 'data', 'structure.example.sql') }
+    let(:expected_filename) { File.join(RSpec::root, 'data', 'structure.expected.sql') }
+    let(:expected_sanitized_content) { File.read(expected_filename) }
 
+    describe '.sanitize' do
+      it 'removes unwanted lines and substrings from structure.sql' do
         actual_sanitized_content = ActiveRecordMySqlStructure::StructureSqlSanitizer.sanitize(filename)
-        expected_sanitized_content = File.read(expected_filename)
         expect(actual_sanitized_content).to eq(expected_sanitized_content)
       end
 
       context 'with sorted columns enabled' do
-        around do |example|
-          begin
-            prev = ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns?
-            ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns = true
-            example.run
-          ensure
-            ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns = prev
-          end
+        subject do
+          ActiveRecordMySqlStructure::StructureSqlSanitizer.new(filename, sorted_columns: true)
         end
 
-        it 'should remove unwanted lines and substrings from structure.sql' do
-          filename = File.join(RSpec::root, 'data', 'structure.example.sql')
-          expected_filename = File.join(RSpec::root, 'data', 'structure.sorted_columns.sql')
+        let(:expected_filename) { File.join(RSpec::root, 'data', 'structure.sorted_columns.sql') }
 
-          actual_sanitized_content = ActiveRecordMySqlStructure::StructureSqlSanitizer.sanitize(filename)
-          expected_sanitized_content = File.read(expected_filename)
-          expect(actual_sanitized_content).to eq(expected_sanitized_content)
+        it 'should remove unwanted lines and substrings from structure.sql' do
+          expect(subject.sanitize!).to eq(expected_sanitized_content)
         end
       end
     end

--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -14,7 +14,7 @@ describe ActiveRecord::Mysql::Structure do
     let(:expected_filename) { File.join(RSpec::root, 'data', 'structure.expected.sql') }
     let(:expected_sanitized_content) { File.read(expected_filename) }
 
-    describe '.sanitize' do
+    describe '#sanitize' do
       it 'removes unwanted lines and substrings from structure.sql' do
         actual_sanitized_content = ActiveRecordMySqlStructure::StructureSqlSanitizer.sanitize(filename)
         expect(actual_sanitized_content).to eq(expected_sanitized_content)

--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -17,6 +17,27 @@ describe ActiveRecord::Mysql::Structure do
         expected_sanitized_content = File.read(expected_filename)
         expect(actual_sanitized_content).to eq(expected_sanitized_content)
       end
+
+      context 'with sorted columns enabled' do
+        around do |example|
+          begin
+            prev = ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns?
+            ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns = true
+            example.run
+          ensure
+            ActiveRecordMySqlStructure::StructureSqlSanitizer.sorted_columns = prev
+          end
+        end
+
+        it 'should remove unwanted lines and substrings from structure.sql' do
+          filename = File.join(RSpec::root, 'data', 'structure.example.sql')
+          expected_filename = File.join(RSpec::root, 'data', 'structure.sorted_columns.sql')
+
+          actual_sanitized_content = ActiveRecordMySqlStructure::StructureSqlSanitizer.sanitize(filename)
+          expected_sanitized_content = File.read(expected_filename)
+          expect(actual_sanitized_content).to eq(expected_sanitized_content)
+        end
+      end
     end
   end
 

--- a/spec/data/structure.sorted_columns.sql
+++ b/spec/data/structure.sorted_columns.sql
@@ -1,0 +1,93 @@
+DROP TABLE IF EXISTS `classified_types`;
+CREATE TABLE `classified_types` (
+  `created_at` datetime DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `classifieds`;
+CREATE TABLE `classifieds` (
+  `classified_type_id` int(11) DEFAULT NULL,
+  `content` text COLLATE utf8_unicode_ci,
+  `created_at` datetime DEFAULT NULL,
+  `dollars` int(11) DEFAULT NULL,
+  `employee_id` int(11) DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `item_img_content_type` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_file_name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `item_img_file_size` int(11) DEFAULT NULL,
+  `item_img_updated_at` datetime DEFAULT NULL,
+  `title` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_classifieds_on_employee_id` (`employee_id`),
+  KEY `index_classifieds_on_classified_type_id` (`classified_type_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `schema_migrations`;
+CREATE TABLE `schema_migrations` (
+  `version` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  UNIQUE KEY `unique_schema_migrations` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+DROP TABLE IF EXISTS `teams`;
+CREATE TABLE `teams` (
+  `created_at` datetime NOT NULL,
+  `description` text COLLATE utf8_unicode_ci,
+  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `updated_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_teams_on_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+
+INSERT INTO schema_migrations (version) VALUES ('20150213221911');
+
+INSERT INTO schema_migrations (version) VALUES ('20150213222926');
+
+INSERT INTO schema_migrations (version) VALUES ('20150213225251');
+
+INSERT INTO schema_migrations (version) VALUES ('20150213230121');
+
+INSERT INTO schema_migrations (version) VALUES ('20150213232012');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214000513');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214004737');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214005057');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214011626');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214013535');
+
+INSERT INTO schema_migrations (version) VALUES ('20150214084227');
+
+INSERT INTO schema_migrations (version) VALUES ('20150216213539');
+
+INSERT INTO schema_migrations (version) VALUES ('20150315230851');
+
+INSERT INTO schema_migrations (version) VALUES ('20150315230955');
+
+INSERT INTO schema_migrations (version) VALUES ('20150319154456');
+
+INSERT INTO schema_migrations (version) VALUES ('20150411191006');
+
+INSERT INTO schema_migrations (version) VALUES ('20150417172914');
+
+INSERT INTO schema_migrations (version) VALUES ('20150418072605');
+
+INSERT INTO schema_migrations (version) VALUES ('20150612174040');
+
+INSERT INTO schema_migrations (version) VALUES ('20150612181455');
+
+INSERT INTO schema_migrations (version) VALUES ('20150612232043');
+
+INSERT INTO schema_migrations (version) VALUES ('20160424213633');


### PR DESCRIPTION
Previously, the columns would remain unsorted. This meant that the order
that they were created/specified in mysql was the order they appeared
in the file. This creates churn for developers that have loaded their
columns in different orders.

This is an optional setting because column order is not actually
portable if you do not specify the columns you are setting during an
update query.